### PR TITLE
BACKLOG-8388 Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,25 +25,26 @@
     <source.jdk.version>1.6</source.jdk.version>
     <dependency.commons-vfs.commons-vfs.version>1.0</dependency.commons-vfs.commons-vfs.version>
     <dependency.commons-lang.commons-lang.version>2.3</dependency.commons-lang.commons-lang.version>
-    <dependency.com.sun.jersey.jersey-client.version>1.11</dependency.com.sun.jersey.jersey-client.version>
+    <dependency.com.sun.jersey.jersey-client.version>1.19.1</dependency.com.sun.jersey.jersey-client.version>
     <dependency.junit.junit.version>4.4</dependency.junit.junit.version>
     <dependency.commons-httpclient.commons-httpclient.version>3.0.1</dependency.commons-httpclient.commons-httpclient.version>
     <plugin.org.apache.maven.plugin.maven-eclipse-plugin.version>2.7</plugin.org.apache.maven.plugin.maven-eclipse-plugin.version>
-    <dependency.com.sun.jersey.contribs.jersey-spring.version>1.11</dependency.com.sun.jersey.contribs.jersey-spring.version>
+    <dependency.javax.ws.rs.jsr311-api.version>1.1.1</dependency.javax.ws.rs.jsr311-api.version>
+    <dependency.com.sun.jersey.contribs.jersey-spring.version>1.19.1</dependency.com.sun.jersey.contribs.jersey-spring.version>
     <dependency.sun.jlfgr.version>1.0</dependency.sun.jlfgr.version>
-    <dependency.com.sun.jersey.jersey-core.version>1.11</dependency.com.sun.jersey.jersey-core.version>
-    <dependency.com.sun.jersey.contribs.jersey-multipart.version>1.11</dependency.com.sun.jersey.contribs.jersey-multipart.version>
+    <dependency.com.sun.jersey.jersey-core.version>1.19.1</dependency.com.sun.jersey.jersey-core.version>
+    <dependency.com.sun.jersey.contribs.jersey-multipart.version>1.19.1</dependency.com.sun.jersey.contribs.jersey-multipart.version>
     <dependency.mysql.mysql-connector-java.version>5.1.21</dependency.mysql.mysql-connector-java.version>
     <dependency.dom4j.dom4j.version>1.6.1</dependency.dom4j.dom4j.version>
     <dependency.commons-logging.commons-logging.version>1.1.1</dependency.commons-logging.commons-logging.version>
-    <dependency.com.sun.jersey.contribs.jersey-apache-client.version>1.11</dependency.com.sun.jersey.contribs.jersey-apache-client.version>
+    <dependency.com.sun.jersey.contribs.jersey-apache-client.version>1.19.1</dependency.com.sun.jersey.contribs.jersey-apache-client.version>
     <dependency.commons-dbcp.commons-dbcp.version>1.4</dependency.commons-dbcp.commons-dbcp.version>
     <dependency.org.olap4j.olap4j.version>1.1.0</dependency.org.olap4j.olap4j.version>
     <dependency.log4j.log4j.version>1.2.17</dependency.log4j.log4j.version>
     <dependency.jaxen.jaxen.version>1.1.1</dependency.jaxen.jaxen.version>
     <target.jdk.version>1.6</target.jdk.version>
-    <dependency.com.sun.jersey.jersey-bundle.version>1.11</dependency.com.sun.jersey.jersey-bundle.version>
-    <dependency.com.sun.jersey.jersey-json.version>1.11</dependency.com.sun.jersey.jersey-json.version>
+    <dependency.com.sun.jersey.jersey-bundle.version>1.19.1</dependency.com.sun.jersey.jersey-bundle.version>
+    <dependency.com.sun.jersey.jersey-json.version>1.19.1</dependency.com.sun.jersey.jersey-json.version>
     <dependency.com.ibm.icu.icu4j.version>3.4.4</dependency.com.ibm.icu.icu4j.version>
     <dependency.commons-math.commons-math.version>1.1</dependency.commons-math.commons-math.version>
   </properties>
@@ -117,6 +118,11 @@
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
       <version>${dependency.jaxen.jaxen.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>jsr311-api</artifactId>
+      <version>${dependency.javax.ws.rs.jsr311-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey.contribs</groupId>


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor